### PR TITLE
more idiomatic Rust parser

### DIFF
--- a/iorgen/parser_rust.py
+++ b/iorgen/parser_rust.py
@@ -3,10 +3,11 @@
 """Generate a Rust parser"""
 
 import textwrap
-from typing import List
+from typing import List, Optional
 from iorgen.types import Input, Struct, Type, TypeEnum, Variable
 from iorgen.utils import pascal_case, snake_case
 
+# Language keywords
 KEYWORDS = [
     "abstract", "alignof", "as", "become", "box", "break", "const", "continue",
     "crate", "do", "else", "enum", "extern", "false", "final", "fn", "for",
@@ -17,15 +18,19 @@ KEYWORDS = [
     "yield"
 ]
 
+# KEYWORDS extended with the list of identifiers used by the generated code
+EXTENDED_KEYWORDS = KEYWORDS + [
+    "buffer", "read_line", "std", "Box", "String", "Vec", "Result"
+]
+
+# Conventional indentation token
 INDENTATION = "    "
 
 
 def var_name(name: str) -> str:
     """Transform a variable name into a valid one for Rust"""
     candidate = snake_case(name)
-    if candidate in KEYWORDS:
-        return candidate + "_"
-    if candidate in ("read_line", "read_vec_int"):
+    if candidate in EXTENDED_KEYWORDS:
         return candidate + "_"
     if candidate.startswith("read_struct_") or candidate.endswith("_elem"):
         return candidate + "_"
@@ -35,9 +40,7 @@ def var_name(name: str) -> str:
 def struct_name(name: str) -> str:
     """Transform a struct name into a valid one for Rust"""
     candidate = pascal_case(name)
-    if candidate in KEYWORDS:
-        return candidate + "_"
-    if candidate in ("Vec", "String"):
+    if candidate in EXTENDED_KEYWORDS:
         return candidate + "_"
     return candidate
 
@@ -52,24 +55,22 @@ def type_str(type_: Type) -> str:
         return "String"
     if type_.main == TypeEnum.STRUCT:
         return struct_name(type_.struct_name)
-    assert type_.main == TypeEnum.LIST
-    assert type_.encapsulated
-    return "Vec<{}>".format(type_str(type_.encapsulated))
+    if type_.main == TypeEnum.LIST:
+        assert type_.encapsulated
+        return "Vec<{}>".format(type_str(type_.encapsulated))
+    raise Exception
 
 
-def decl_struct(struct: Struct) -> List[str]:
-    """Return the Rust code for declaring a struct"""
-    lines = [
-        "/// " + struct.comment,
-        "struct {} {{".format(struct_name(struct.name))
-    ]
-    for field in struct.fields:
-        lines.extend([
-            INDENTATION + "/// " + field.comment,
-            "{}{}: {},".format(INDENTATION, var_name(field.name),
-                               type_str(field.type))
-        ])
-    return lines + ["}", ""]
+def parse_without_error(type_: Type) -> bool:
+    """Check if a type can be parsed without being wrapped in a result"""
+    if type_.main == TypeEnum.STR:
+        return True
+
+    if type_.main == TypeEnum.LIST:
+        assert type_.encapsulated is not None
+        return type_.encapsulated.main == TypeEnum.CHAR
+
+    return False
 
 
 class ParserRust():
@@ -80,104 +81,228 @@ class ParserRust():
         self.call_site = []  # type: List[str]
         self.read_vec_int = False
 
+    def struct_is_copy(self, struct: Struct) -> bool:
+        """Check if the generated Rust structure can be marked as Copy"""
+        return all(self.is_copy(t) for t in struct.fields)
+
+    def is_copy(self, var: Variable) -> bool:
+        """
+        Check if the generated Rust type for a variable can be marked as Copy
+        """
+        type_ = var.type.main
+
+        if type_ in [TypeEnum.CHAR, TypeEnum.INT]:
+            return True
+
+        if type_ in [TypeEnum.LIST, TypeEnum.STR]:
+            return False
+
+        if type_ == TypeEnum.STRUCT:
+            return self.struct_is_copy(
+                self.input.get_struct(var.type.struct_name))
+
+        raise Exception
+
+    def decl_struct(self, struct: Struct) -> List[str]:
+        """Return the Rust code for declaring a struct"""
+        copy = " Copy," if self.struct_is_copy(struct) else ""
+
+        lines = [
+            f"/// {struct.comment}",
+            f"#[derive(Clone,{copy} Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]",
+            f"struct {struct_name(struct.name)} {{"
+        ]
+
+        for field in struct.fields:
+            lines += [
+                f"    /// {field.comment}",
+                f"    {var_name(field.name)}: {type_str(field.type)},"
+            ]
+
+        return lines + ["}", ""]
+
     def def_read_struct(self, struct: Struct) -> List[str]:
         """Return a rust function reading a parsing a struct"""
-        lines = [
-            "fn read_struct_{}() -> {} {{".format(snake_case(struct.name),
-                                                  struct_name(struct.name))
-        ]
+        s_name = struct_name(struct.name)
+
         if Type(TypeEnum.STRUCT,
                 struct_name=struct.name).fits_in_one_line(self.input.structs):
-            lines.extend([
-                INDENTATION + "let line = read_line();", INDENTATION +
-                "let words: Vec<&str> = line.split_whitespace().collect();",
-                INDENTATION + "{} {{".format(struct_name(struct.name))
-            ])
-            lines.extend("{}{}: words[{}].parse().unwrap(),".format(
-                2 * INDENTATION, var_name(field.name), i)
-                         for i, field in enumerate(struct.fields))
-            lines.append(INDENTATION + "}")
-        else:
-            for field in struct.fields:
-                lines.extend(
-                    self.read_var(
-                        Variable(field.name, field.comment, field.type)))
-            lines.append("{}{} {{ {} }}".format(
-                INDENTATION, struct_name(struct.name),
-                ", ".join(var_name(f.name) for f in struct.fields)))
-        return lines + ["}"]
+            lines = [
+                f"impl std::str::FromStr for {s_name} {{",
+                u"    type Err = Box<dyn std::error::Error>;",
+                u"",
+                u"    fn from_str(line: &str) -> Result<Self, Self::Err> {",
+                u"        let mut line = line.split_whitespace();",
+                u"        Ok(Self {",
+            ]
 
-    def read_line(self, type_: Type) -> str:
+            for field in struct.fields:
+                name = var_name(field.name)
+                lines.append(
+                    u'            '
+                    f'{name}: line.next().ok_or("missing `{name}`")?.parse()?,',
+                )
+
+            return lines + [
+                "        })",
+                "    }",
+                "}",
+            ]
+
+        fields = ", ".join(var_name(field.name) for field in struct.fields)
+        lines = []
+        lines.append(
+            f"fn read_struct_{snake_case(struct.name)}(mut buffer: &mut String)"
+            f" -> Result<{s_name}, Box<dyn std::error::Error>> {{")
+
+        for field in struct.fields:
+            lines.append(self.read_var(field, in_error_context=True))
+
+        return lines + [
+            f"    Ok({s_name} {{ {fields} }})",
+            u"}",
+        ]
+
+    def read_line(
+        self,
+        type_: Type,
+        indent_lvl: int,
+        name: Optional[str] = None,
+        unwrap_method: Optional[str] = None,
+    ) -> str:
         """Return a Rust command for parsing a line into a given type"""
         assert type_.fits_in_one_line(self.input.structs)
-        if type_.main in (TypeEnum.INT, TypeEnum.CHAR):
-            return "read_line().parse().unwrap()"
+
+        if unwrap_method is None:
+            if name:
+                unwrap_method = f'.expect("invalid `{name}` parameter")'
+            else:
+                unwrap_method = ".unwrap()"
+
+        if type_.main in (TypeEnum.INT, TypeEnum.CHAR, TypeEnum.STRUCT):
+            code = [
+                "read_line(&mut buffer)",
+                ".parse()",
+                unwrap_method,
+            ]
+
+            if len(unwrap_method) < 10:
+                separator = ""
+            else:
+                separator = "\n" + (indent_lvl + 1) * INDENTATION
+
+            return separator.join(code)
+
         if type_.main == TypeEnum.STR:
-            return "read_line()"
+            return "read_line(&mut buffer).to_string()"
+
         if type_.main == TypeEnum.LIST:
             assert type_.encapsulated is not None
+
             if type_.encapsulated.main == TypeEnum.INT:
                 self.read_vec_int = True
-                return "read_vec_int()"
-            if type_.encapsulated.main == TypeEnum.CHAR:
-                return "read_line().chars().collect()"
-        if type_.main == TypeEnum.STRUCT:
-            return "read_struct_{}()".format(snake_case(type_.struct_name))
-        assert False
-        return ""
+                idt = (indent_lvl + 1) * INDENTATION
+                lines = [
+                    u"read_line(&mut buffer)",
+                    f"{idt}.split_whitespace()",
+                    f"{idt}.map(str::parse)",
+                    f"{idt}.collect::<Result<_, _>>()",
+                ]
 
-    def read_lines(self, name: str, type_: Type, indent_lvl: int) -> List[str]:
+                if unwrap_method == "?":
+                    lines[-1] += "?"
+                elif unwrap_method:
+                    lines.append(f"{idt}{unwrap_method}")
+
+                return "\n".join(lines)
+
+            if type_.encapsulated.main == TypeEnum.CHAR:
+                return "read_line(&mut buffer).chars().collect()"
+
+        raise Exception
+
+    def read_lines(self,
+                   name: str,
+                   type_: Type,
+                   indent_lvl: int,
+                   unwrap_method: Optional[str] = None) -> List[str]:
         """Return a Rust command for parsing some lines into a given type"""
         assert not type_.fits_in_one_line(self.input.structs)
+
+        if unwrap_method is None:
+            unwrap_method = f'.expect("invalid `{name}` parameter")'
+
         if type_.main == TypeEnum.STRUCT:
             return [
-                "{}let {}: {} = read_struct_{}();".format(
-                    INDENTATION * indent_lvl, name, type_str(type_),
-                    snake_case(type_.struct_name))
+                f"read_struct_{snake_case(type_.struct_name)}(&mut buffer){unwrap_method}"
             ]
+
         if type_.main == TypeEnum.LIST:
             assert type_.encapsulated is not None
-            lines = [
-                INDENTATION * indent_lvl +
-                "let mut {}: {} = Vec::with_capacity({} as usize);".format(
-                    name, type_str(type_), var_name(type_.size)),
-                INDENTATION * indent_lvl +
-                "for _ in 0..{} {{".format(var_name(type_.size))
-            ]
-            if type_.encapsulated.fits_in_one_line(self.input.structs):
-                lines.append(INDENTATION * (indent_lvl + 1) +
-                             "{}.push({});".format(
-                                 name, self.read_line(type_.encapsulated)))
-            else:
-                lines.extend(
-                    self.read_lines("{}_elem".format(name.replace(".", "_")),
-                                    type_.encapsulated, indent_lvl + 1))
-                lines.append(INDENTATION * (indent_lvl + 1) +
-                             "{0}.push({0}_elem);".format(name))
-            return lines + [INDENTATION * indent_lvl + "}"]
-        assert False
-        return []
 
-    def read_var(self, var: Variable) -> List[str]:
+            if type_.encapsulated.fits_in_one_line(self.input.structs):
+                line_read = self.read_line(
+                    type_.encapsulated,
+                    indent_lvl + 2,
+                    name.replace(".", "_") + "_elem",
+                    unwrap_method="",
+                )
+            else:
+                line_read = "\n".join(
+                    self.read_lines(name.replace(".", "_") + "_elem",
+                                    type_.encapsulated,
+                                    indent_lvl + 2,
+                                    unwrap_method=""))
+
+            idt = (indent_lvl + 1) * INDENTATION
+            lines = [f"(0..{var_name(type_.size)})"]
+
+            if line_read.count("\n") == 0:
+                lines.append(f"{idt}.map(|_| {line_read})")
+            else:
+                lines += [
+                    f"{idt}.map(|_| {{",
+                    f"{idt}    {line_read}",
+                    f"{idt}}})",
+                ]
+
+            if parse_without_error(type_.encapsulated):
+                # read_lines doesn't return a Result
+                lines.append(f"{idt}.collect()")
+            else:
+                lines.append(f"{idt}.collect::<Result<_, _>>()")
+
+                if unwrap_method == "?":
+                    lines[-1] += "?"
+                elif unwrap_method:
+                    lines.append(f"{idt}{unwrap_method}")
+
+            return lines
+
+        raise Exception
+
+    def read_var(self, var: Variable, in_error_context: bool = False) -> str:
         """Return a Rust command for parsing a variable"""
+        name = var_name(var.name)
+        unwrap_method = '?' if in_error_context else None
+
         if var.type.fits_in_one_line(self.input.structs):
-            return [
-                INDENTATION +
-                "let {}: {} = {};".format(var_name(var.name), type_str(
-                    var.type), self.read_line(var.type))
-            ]
-        return self.read_lines(var_name(var.name), var.type, 1)
+            read_method = self.read_line(var.type, 1, var.name, unwrap_method)
+        else:
+            read_method = "\n".join(
+                self.read_lines(name, var.type, 1, unwrap_method))
+
+        return f"    let {name} = {read_method};"
 
     def method(self, reprint: bool) -> List[str]:
         """Declare and call the function take all inputs in arguments"""
-        lines = [
-            "/// * `{}` - {}".format(var_name(var.name), var.comment)
-            for var in self.input.input
-        ]
-        lines.append("fn {}({}) {{".format(
-            var_name(self.input.name),
-            ", ".join("{}: {}".format(var_name(var.name), type_str(var.type))
-                      for var in self.input.input)))
+        args = [(var_name(var.name), type_str(var.type), var.comment)
+                for var in self.input.input]
+        lines = [f"/// * `{arg}` - {comment}" for arg, _, comment in args]
+
+        args_decl = ", ".join(f"{arg}: {atype}" for arg, atype, _ in args)
+        lines.append(f"fn {var_name(self.input.name)}({args_decl}) {{")
+
         if reprint:
             for var in self.input.input:
                 lines.extend(self.print_lines(var_name(var.name), var.type, 1))
@@ -186,92 +311,121 @@ class ParserRust():
                 INDENTATION + i
                 for i in textwrap.wrap("/* TODO " + self.input.output +
                                        " */", 79 - len(INDENTATION)))
+
         return lines + ["}"]
 
     def print_line(self, name: str, type_: Type) -> str:
         """Print the content of a var that holds in one line"""
         assert type_.fits_in_one_line(self.input.structs)
+
         if type_.main in (TypeEnum.INT, TypeEnum.CHAR, TypeEnum.STR):
-            return 'print!("{{}}\\n", {});'.format(name)
+            return f'print!("{{}}\\n", {name});'
+
         if type_.main == TypeEnum.LIST:
             assert type_.encapsulated is not None
             to_string = ""
+
             if type_.encapsulated.main == TypeEnum.INT:
-                to_string = 'iter().map(|x| x.to_string())' + \
-                            '.collect::<Vec<String>>().join(" ")'
-            else:
-                assert type_.encapsulated.main == TypeEnum.CHAR
+                to_string = 'iter().map(|x| x.to_string()).collect::<Vec<_>>().join(" ")'
+            elif type_.encapsulated.main == TypeEnum.CHAR:
                 to_string = 'into_iter().collect::<String>()'
-            return 'print!("{{}}\\n", {}.{});'.format(name, to_string)
-        assert type_.main == TypeEnum.STRUCT
-        struct = self.input.get_struct(type_.struct_name)
-        return 'print!("{}\\n", {});'.format(
-            " ".join(["{}"] * len(struct.fields)),
-            ", ".join(name + "." + var_name(f.name) for f in struct.fields))
+            else:
+                raise Exception
+
+            return f'print!("{{}}\\n", {name}.{to_string});'
+
+        if type_.main == TypeEnum.STRUCT:
+            struct = self.input.get_struct(type_.struct_name)
+            template = " ".join(["{}"] * len(struct.fields))
+            fields = ", ".join(f"{name}.{var_name(f.name)}"
+                               for f in struct.fields)
+            return f'print!("{template}\\n", {fields});'
+
+        raise Exception
 
     def print_lines(self, name: str, type_: Type,
                     indent_lvl: int) -> List[str]:
         """Print the content of a var that holds in one or more lines"""
-        indent = INDENTATION * indent_lvl
+        idt = INDENTATION * indent_lvl
+
         if type_.fits_in_one_line(self.input.structs):
-            return [indent + self.print_line(name, type_)]
+            return [idt + self.print_line(name, type_)]
+
         if type_.main == TypeEnum.STRUCT:
-            lines = []
-            for field in self.input.get_struct(type_.struct_name).fields:
-                lines.extend(
-                    self.print_lines(name + "." + var_name(field.name),
-                                     field.type, indent_lvl))
-            return lines
-        assert type_.main == TypeEnum.LIST
-        assert type_.encapsulated is not None
-        inner_name = "{}_elem".format(name.replace(".", "_"))
-        lines = ["{}for {} in &{} {{".format(indent, inner_name, name)]
-        lines.extend(
-            self.print_lines(inner_name, type_.encapsulated, indent_lvl + 1))
-        return lines + [indent + "}"]
+            return sum(
+                (self.print_lines(f"{name}.{var_name(field.name)}", field.type,
+                                  indent_lvl)
+                 for field in self.input.get_struct(type_.struct_name).fields),
+                [])
+
+        if type_.main == TypeEnum.LIST:
+            assert type_.encapsulated is not None
+            inner_name = name.replace(".", "_") + "_elem"
+            return [
+                f"{idt}for {inner_name} in &{name} {{",
+                *self.print_lines(inner_name, type_.encapsulated,
+                                  indent_lvl + 1),
+                f"{idt}}}",
+            ]
+
+        raise Exception
 
     def content(self, reprint: bool) -> str:
         """Return the parser content"""
         read_vars = []
+
         for var in self.input.input:
-            read_vars.extend(self.read_var(var))
+            read_vars.append(self.read_var(var))
+            read_vars.append("")
+
         structs = [
             self.def_read_struct(struct) for struct in self.input.structs
         ]
 
-        output = ""
-        if self.input.input:  # There are stuff to parse
-            output += "use std::io;\n\n"
+        output_lines: List[str] = []
+
+        # Structs declaration
+
         for struct in self.input.structs:
-            output += "\n".join(decl_struct(struct)) + "\n"
-        output += "\n".join(self.method(reprint)) + "\n\n"
-        output += "fn main() {\n"
-        output += "\n".join(read_vars) + "\n"
-        args = (var_name(var.name) for var in self.input.input)
-        output += "\n{}{}({});\n".format(INDENTATION,
-                                         var_name(self.input.name),
-                                         ", ".join(args))
-        output += "}\n"
+            output_lines += self.decl_struct(struct)
+
+        # Function that has to be completed
+
+        output_lines += self.method(reprint)
+        output_lines.append("")
+
+        # Main function
+
+        output_lines.append("fn main() {")
+
         if self.input.input:  # There are stuff to parse
-            output += "\nfn read_line() -> String {\n"
-            output += INDENTATION + "let mut line = String::new();\n"
-            output += INDENTATION + "io::stdin()\n"
-            output += 2 * INDENTATION + ".read_line(&mut line)\n"
-            output += 2 * INDENTATION + '.expect("Failed to read line");\n'
-            output += INDENTATION + "line.trim().to_string()\n"
-            output += "}\n"
-        if self.read_vec_int:
-            output += "\nfn read_vec_int() -> Vec<i32> {\n"
-            output += INDENTATION + "read_line()\n"
-            output += 2 * INDENTATION + ".split_whitespace()\n"
-            output += 2 * INDENTATION + ".collect::<Vec<&str>>()\n"
-            output += 2 * INDENTATION + ".iter()\n"
-            output += 2 * INDENTATION + ".map(|x| x.parse().unwrap())\n"
-            output += 2 * INDENTATION + ".collect()\n"
-            output += "}\n"
+            output_lines += ["    let mut buffer = String::new();", ""]
+            output_lines += read_vars
+
+        args = ", ".join(var_name(var.name) for var in self.input.input)
+        output_lines.append(f"    {var_name(self.input.name)}({args});")
+        output_lines.append("}")
+
+        # Custom parse methods
+
+        if self.input.input:
+            output_lines += [
+                "",
+                "fn read_line(mut buffer: &mut String) -> &str {",
+                "    buffer.clear();",
+                "    std::io::stdin()",
+                "        .read_line(&mut buffer)",
+                '        .expect("impossible to read a new line");',
+                "    buffer.trim_end()",
+                "}",
+            ]
+
         for struct_def in structs:
-            output += "\n" + "\n".join(struct_def) + "\n"
-        return output
+            output_lines.append("")
+            output_lines += struct_def
+
+        output_lines.append("")
+        return "\n".join(output_lines)
 
 
 def gen_rust(input_data: Input, reprint: bool = False) -> str:

--- a/iorgen/types.py
+++ b/iorgen/types.py
@@ -80,8 +80,7 @@ class Type:
             return "List[{}]({})".format(self.encapsulated, self.size)
         if self.main == TypeEnum.STRUCT:
             return "@{}".format(self.struct_name)
-        assert False
-        return "UNKNOWN_TYPE"
+        raise Exception
 
     def can_be_inlined(self: TYPE) -> bool:
         """Can we parse several of this type on a single line"""
@@ -97,8 +96,7 @@ class Type:
         if self.main == TypeEnum.STRUCT:
             struct = next(x for x in structs if x.name == self.struct_name)
             return all(i.type.can_be_inlined() for i in struct.fields)
-        assert False
-        return True
+        raise Exception
 
     def list_contained(self: TYPE) -> TYPE:
         """Return non-list type contained is list (or list of list, etc)"""
@@ -280,8 +278,7 @@ class Variable:
                 return "{} ϵ {{{}}}".format(name, (", ".join(
                     str(i) for i in sorted(self.constraints.choices))))
             return ""
-        assert False
-        return ""
+        raise Exception
 
 
 class Struct:

--- a/test/samples/emptylines/emptylines.rs
+++ b/test/samples/emptylines/emptylines.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 /// a char struct
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct StructWithAChar {
     /// a char
     char1: char,
@@ -9,6 +8,7 @@ struct StructWithAChar {
 }
 
 /// a struct
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct A {
     /// a list in a struct
     list_in_struct: Vec<i32>,
@@ -17,6 +17,7 @@ struct A {
 }
 
 /// a sized struct
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct SizedStruct {
     /// the size
     size: i32,
@@ -40,55 +41,74 @@ fn empty_lines(empty_list: Vec<i32>, buffer_string: String, n: i32, empty_in_sam
 }
 
 fn main() {
-    let empty_list: Vec<i32> = read_vec_int();
-    let buffer_string: String = read_line();
-    let n: i32 = read_line().parse().unwrap();
-    let empty_in_sample: Vec<i32> = read_vec_int();
-    let empty_string: String = read_line();
-    let main: String = read_line();
-    let empty_char_list: Vec<char> = read_line().chars().collect();
-    let non_empty_char_list: Vec<char> = read_line().chars().collect();
-    let struct_with_empty_line: A = read_struct_a();
-    let a_sized_struct: SizedStruct = read_struct_sized_struct();
-    let finish: String = read_line();
+    let mut buffer = String::new();
+
+    let empty_list = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .expect("invalid `empty list` parameter");
+
+    let buffer_string = read_line(&mut buffer).to_string();
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `N` parameter");
+
+    let empty_in_sample = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .expect("invalid `empty in sample` parameter");
+
+    let empty_string = read_line(&mut buffer).to_string();
+
+    let main = read_line(&mut buffer).to_string();
+
+    let empty_char_list = read_line(&mut buffer).chars().collect();
+
+    let non_empty_char_list = read_line(&mut buffer).chars().collect();
+
+    let struct_with_empty_line = read_struct_a(&mut buffer).expect("invalid `struct_with_empty_line` parameter");
+
+    let a_sized_struct = read_struct_sized_struct(&mut buffer).expect("invalid `a_sized_struct` parameter");
+
+    let finish = read_line(&mut buffer).to_string();
 
     empty_lines(empty_list, buffer_string, n, empty_in_sample, empty_string, main, empty_char_list, non_empty_char_list, struct_with_empty_line, a_sized_struct, finish);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }
 
-fn read_vec_int() -> Vec<i32> {
-    read_line()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .iter()
-        .map(|x| x.parse().unwrap())
-        .collect()
-}
+impl std::str::FromStr for StructWithAChar {
+    type Err = Box<dyn std::error::Error>;
 
-fn read_struct_struct_with_a_char() -> StructWithAChar {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    StructWithAChar {
-        char1: words[0].parse().unwrap(),
-        int2: words[1].parse().unwrap(),
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            char1: line.next().ok_or("missing `char1`")?.parse()?,
+            int2: line.next().ok_or("missing `int2`")?.parse()?,
+        })
     }
 }
 
-fn read_struct_a() -> A {
-    let list_in_struct: Vec<i32> = read_vec_int();
-    let struct_in_struct: StructWithAChar = read_struct_struct_with_a_char();
-    A { list_in_struct, struct_in_struct }
+fn read_struct_a(mut buffer: &mut String) -> Result<A, Box<dyn std::error::Error>> {
+    let list_in_struct = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()?;
+    let struct_in_struct = read_line(&mut buffer).parse()?;
+    Ok(A { list_in_struct, struct_in_struct })
 }
 
-fn read_struct_sized_struct() -> SizedStruct {
-    let size: i32 = read_line().parse().unwrap();
-    let string_in_struct: String = read_line();
-    SizedStruct { size, string_in_struct }
+fn read_struct_sized_struct(mut buffer: &mut String) -> Result<SizedStruct, Box<dyn std::error::Error>> {
+    let size = read_line(&mut buffer).parse()?;
+    let string_in_struct = read_line(&mut buffer).to_string();
+    Ok(SizedStruct { size, string_in_struct })
 }

--- a/test/samples/example/example.rs
+++ b/test/samples/example/example.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 /// A struct for the example
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct AStruct {
     /// an integer
     integer: i32,
@@ -16,28 +15,36 @@ fn example(n: i32, list: Vec<AStruct>) {
 }
 
 fn main() {
-    let n: i32 = read_line().parse().unwrap();
-    let mut list: Vec<AStruct> = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        list.push(read_struct_a_struct());
-    }
+    let mut buffer = String::new();
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `N` parameter");
+
+    let list = (0..n)
+        .map(|_| read_line(&mut buffer).parse())
+        .collect::<Result<_, _>>()
+        .expect("invalid `list` parameter");
 
     example(n, list);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }
 
-fn read_struct_a_struct() -> AStruct {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    AStruct {
-        integer: words[0].parse().unwrap(),
-        character: words[1].parse().unwrap(),
+impl std::str::FromStr for AStruct {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            integer: line.next().ok_or("missing `integer`")?.parse()?,
+            character: line.next().ok_or("missing `character`")?.parse()?,
+        })
     }
 }

--- a/test/samples/keywords/keywords.rs
+++ b/test/samples/keywords/keywords.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 /// may conflict in c#
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Console {
     /// the first letter of the alphabet
     a: i32,
@@ -9,6 +8,7 @@ struct Console {
 }
 
 /// may conflict in c#
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct System {
     /// not the end of the function
     return_: i32,
@@ -17,6 +17,7 @@ struct System {
 }
 
 /// not the main function
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Main {
     /// not an integer
     int: System,
@@ -35,54 +36,67 @@ fn keywords(if_: i32, class: char, i: String, in_: Console, for_: Vec<i32>, word
 }
 
 fn main() {
-    let if_: i32 = read_line().parse().unwrap();
-    let class: char = read_line().parse().unwrap();
-    let i: String = read_line();
-    let in_: Console = read_struct_console();
-    let for_: Vec<i32> = read_vec_int();
-    let mut words: Vec<Main> = Vec::with_capacity(2 as usize);
-    for _ in 0..2 {
-        let words_elem: Main = read_struct_main();
-        words.push(words_elem);
-    }
+    let mut buffer = String::new();
+
+    let if_ = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `if` parameter");
+
+    let class = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `class` parameter");
+
+    let i = read_line(&mut buffer).to_string();
+
+    let in_ = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `in` parameter");
+
+    let for_ = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .expect("invalid `for` parameter");
+
+    let words = (0..2)
+        .map(|_| read_struct_main(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `words` parameter");
 
     keywords(if_, class, i, in_, for_, words);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }
 
-fn read_vec_int() -> Vec<i32> {
-    read_line()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .iter()
-        .map(|x| x.parse().unwrap())
-        .collect()
-}
+impl std::str::FromStr for Console {
+    type Err = Box<dyn std::error::Error>;
 
-fn read_struct_console() -> Console {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    Console {
-        a: words[0].parse().unwrap(),
-        static_: words[1].parse().unwrap(),
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            a: line.next().ok_or("missing `a`")?.parse()?,
+            static_: line.next().ok_or("missing `static_`")?.parse()?,
+        })
     }
 }
 
-fn read_struct_system() -> System {
-    let return_: i32 = read_line().parse().unwrap();
-    let void: Vec<i32> = read_vec_int();
-    System { return_, void }
+fn read_struct_system(mut buffer: &mut String) -> Result<System, Box<dyn std::error::Error>> {
+    let return_ = read_line(&mut buffer).parse()?;
+    let void = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()?;
+    Ok(System { return_, void })
 }
 
-fn read_struct_main() -> Main {
-    let int: System = read_struct_system();
-    let if_true: i32 = read_line().parse().unwrap();
-    Main { int, if_true }
+fn read_struct_main(mut buffer: &mut String) -> Result<Main, Box<dyn std::error::Error>> {
+    let int = read_struct_system(&mut buffer)?;
+    let if_true = read_line(&mut buffer).parse()?;
+    Ok(Main { int, if_true })
 }

--- a/test/samples/lists/lists.rs
+++ b/test/samples/lists/lists.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 /// * `n` - the first list's size
 /// * `list_int` - a list containing ints
 /// * `size` - an other size
@@ -12,36 +10,47 @@ fn lists(n: i32, list_int: Vec<i32>, size: i32, list_char: Vec<char>, string: St
 }
 
 fn main() {
-    let n: i32 = read_line().parse().unwrap();
-    let list_int: Vec<i32> = read_vec_int();
-    let size: i32 = read_line().parse().unwrap();
-    let list_char: Vec<char> = read_line().chars().collect();
-    let string: String = read_line();
-    let mut list_string4: Vec<String> = Vec::with_capacity(size as usize);
-    for _ in 0..size {
-        list_string4.push(read_line());
-    }
-    let mut matrix: Vec<Vec<i32>> = Vec::with_capacity(size as usize);
-    for _ in 0..size {
-        matrix.push(read_vec_int());
-    }
+    let mut buffer = String::new();
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `N` parameter");
+
+    let list_int = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()
+        .expect("invalid `list int` parameter");
+
+    let size = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `size` parameter");
+
+    let list_char = read_line(&mut buffer).chars().collect();
+
+    let string = read_line(&mut buffer).to_string();
+
+    let list_string4 = (0..size)
+        .map(|_| read_line(&mut buffer).to_string())
+        .collect();
+
+    let matrix = (0..size)
+        .map(|_| {
+            read_line(&mut buffer)
+                .split_whitespace()
+                .map(str::parse)
+                .collect::<Result<_, _>>()
+        })
+        .collect::<Result<_, _>>()
+        .expect("invalid `matrix` parameter");
 
     lists(n, list_int, size, list_char, string, list_string4, matrix);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
-}
-
-fn read_vec_int() -> Vec<i32> {
-    read_line()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .iter()
-        .map(|x| x.parse().unwrap())
-        .collect()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }

--- a/test/samples/simple/simple.rs
+++ b/test/samples/simple/simple.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 /// * `n` - the first number
 /// * `other_number` - the second number
 fn simple(n: i32, other_number: i32) {
@@ -7,16 +5,23 @@ fn simple(n: i32, other_number: i32) {
 }
 
 fn main() {
-    let n: i32 = read_line().parse().unwrap();
-    let other_number: i32 = read_line().parse().unwrap();
+    let mut buffer = String::new();
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `N` parameter");
+
+    let other_number = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `other number` parameter");
 
     simple(n, other_number);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }

--- a/test/samples/sizedstruct/sizedstruct.rs
+++ b/test/samples/sizedstruct/sizedstruct.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 /// contains a list
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct List {
     /// the list's size
     size1: i32,
@@ -9,6 +8,7 @@ struct List {
 }
 
 /// contains a string
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct String_ {
     /// the list's size
     size2: i32,
@@ -17,6 +17,7 @@ struct String_ {
 }
 
 /// contains a matrix
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Matrix {
     /// the list's size
     size3: i32,
@@ -25,6 +26,7 @@ struct Matrix {
 }
 
 /// this is not a 'sized struct', but a regular one!
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct NotASizedStruct {
     /// not the list's size
     size4: i32,
@@ -42,71 +44,76 @@ fn sized_struct(n: i32, lists: Vec<List>, strings: Vec<String_>, matrices: Vec<M
 }
 
 fn main() {
-    let n: i32 = read_line().parse().unwrap();
-    let mut lists: Vec<List> = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        let lists_elem: List = read_struct_list();
-        lists.push(lists_elem);
-    }
-    let mut strings: Vec<String_> = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        let strings_elem: String_ = read_struct_string();
-        strings.push(strings_elem);
-    }
-    let mut matrices: Vec<Matrix> = Vec::with_capacity(2 as usize);
-    for _ in 0..2 {
-        let matrices_elem: Matrix = read_struct_matrix();
-        matrices.push(matrices_elem);
-    }
-    let mut same: Vec<NotASizedStruct> = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        let same_elem: NotASizedStruct = read_struct_not_a_sized_struct();
-        same.push(same_elem);
-    }
+    let mut buffer = String::new();
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `n` parameter");
+
+    let lists = (0..n)
+        .map(|_| read_struct_list(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `lists` parameter");
+
+    let strings = (0..n)
+        .map(|_| read_struct_string(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `strings` parameter");
+
+    let matrices = (0..2)
+        .map(|_| read_struct_matrix(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `matrices` parameter");
+
+    let same = (0..n)
+        .map(|_| read_struct_not_a_sized_struct(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `same` parameter");
 
     sized_struct(n, lists, strings, matrices, same);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }
 
-fn read_vec_int() -> Vec<i32> {
-    read_line()
+fn read_struct_list(mut buffer: &mut String) -> Result<List, Box<dyn std::error::Error>> {
+    let size1 = read_line(&mut buffer).parse()?;
+    let int_list = read_line(&mut buffer)
         .split_whitespace()
-        .collect::<Vec<&str>>()
-        .iter()
-        .map(|x| x.parse().unwrap())
-        .collect()
+        .map(str::parse)
+        .collect::<Result<_, _>>()?;
+    Ok(List { size1, int_list })
 }
 
-fn read_struct_list() -> List {
-    let size1: i32 = read_line().parse().unwrap();
-    let int_list: Vec<i32> = read_vec_int();
-    List { size1, int_list }
+fn read_struct_string(mut buffer: &mut String) -> Result<String_, Box<dyn std::error::Error>> {
+    let size2 = read_line(&mut buffer).parse()?;
+    let string_list = read_line(&mut buffer).to_string();
+    Ok(String_ { size2, string_list })
 }
 
-fn read_struct_string() -> String_ {
-    let size2: i32 = read_line().parse().unwrap();
-    let string_list: String = read_line();
-    String_ { size2, string_list }
+fn read_struct_matrix(mut buffer: &mut String) -> Result<Matrix, Box<dyn std::error::Error>> {
+    let size3 = read_line(&mut buffer).parse()?;
+    let list_list = (0..size3)
+        .map(|_| {
+            read_line(&mut buffer)
+                .split_whitespace()
+                .map(str::parse)
+                .collect::<Result<_, _>>()
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(Matrix { size3, list_list })
 }
 
-fn read_struct_matrix() -> Matrix {
-    let size3: i32 = read_line().parse().unwrap();
-    let mut list_list: Vec<Vec<i32>> = Vec::with_capacity(size3 as usize);
-    for _ in 0..size3 {
-        list_list.push(read_vec_int());
-    }
-    Matrix { size3, list_list }
-}
-
-fn read_struct_not_a_sized_struct() -> NotASizedStruct {
-    let size4: i32 = read_line().parse().unwrap();
-    let int_list_n: Vec<i32> = read_vec_int();
-    NotASizedStruct { size4, int_list_n }
+fn read_struct_not_a_sized_struct(mut buffer: &mut String) -> Result<NotASizedStruct, Box<dyn std::error::Error>> {
+    let size4 = read_line(&mut buffer).parse()?;
+    let int_list_n = read_line(&mut buffer)
+        .split_whitespace()
+        .map(str::parse)
+        .collect::<Result<_, _>>()?;
+    Ok(NotASizedStruct { size4, int_list_n })
 }

--- a/test/samples/structs/structs.rs
+++ b/test/samples/structs/structs.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 /// A simple struct
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Struct1 {
     /// a field
     foo: i32,
@@ -9,6 +8,7 @@ struct Struct1 {
 }
 
 /// Represents a position
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Position {
     /// X
     x: i32,
@@ -19,6 +19,7 @@ struct Position {
 }
 
 /// A point's name and position
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Point {
     /// the point's name (single character)
     name: char,
@@ -29,6 +30,7 @@ struct Point {
 }
 
 /// a struct of chars
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Chars {
     /// a first char
     first_char: char,
@@ -48,62 +50,82 @@ fn structs(struct_: Struct1, n: i32, struct_list: Vec<Struct1>, triangle: Vec<Po
 }
 
 fn main() {
-    let struct_: Struct1 = read_struct_struct_1();
-    let n: i32 = read_line().parse().unwrap();
-    let mut struct_list: Vec<Struct1> = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        struct_list.push(read_struct_struct_1());
-    }
-    let mut triangle: Vec<Point> = Vec::with_capacity(3 as usize);
-    for _ in 0..3 {
-        let triangle_elem: Point = read_struct_point();
-        triangle.push(triangle_elem);
-    }
-    let struct_chars: Chars = read_struct_chars();
+    let mut buffer = String::new();
+
+    let struct_ = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `struct` parameter");
+
+    let n = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `n` parameter");
+
+    let struct_list = (0..n)
+        .map(|_| read_line(&mut buffer).parse())
+        .collect::<Result<_, _>>()
+        .expect("invalid `struct_list` parameter");
+
+    let triangle = (0..3)
+        .map(|_| read_struct_point(&mut buffer))
+        .collect::<Result<_, _>>()
+        .expect("invalid `triangle` parameter");
+
+    let struct_chars = read_line(&mut buffer)
+        .parse()
+        .expect("invalid `struct chars` parameter");
 
     structs(struct_, n, struct_list, triangle, struct_chars);
 }
 
-fn read_line() -> String {
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .expect("Failed to read line");
-    line.trim().to_string()
+fn read_line(mut buffer: &mut String) -> &str {
+    buffer.clear();
+    std::io::stdin()
+        .read_line(&mut buffer)
+        .expect("impossible to read a new line");
+    buffer.trim_end()
 }
 
-fn read_struct_struct_1() -> Struct1 {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    Struct1 {
-        foo: words[0].parse().unwrap(),
-        bar: words[1].parse().unwrap(),
+impl std::str::FromStr for Struct1 {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            foo: line.next().ok_or("missing `foo`")?.parse()?,
+            bar: line.next().ok_or("missing `bar`")?.parse()?,
+        })
     }
 }
 
-fn read_struct_position() -> Position {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    Position {
-        x: words[0].parse().unwrap(),
-        y: words[1].parse().unwrap(),
-        z: words[2].parse().unwrap(),
+impl std::str::FromStr for Position {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            x: line.next().ok_or("missing `x`")?.parse()?,
+            y: line.next().ok_or("missing `y`")?.parse()?,
+            z: line.next().ok_or("missing `z`")?.parse()?,
+        })
     }
 }
 
-fn read_struct_point() -> Point {
-    let name: char = read_line().parse().unwrap();
-    let description: String = read_line();
-    let pos: Position = read_struct_position();
-    Point { name, description, pos }
+fn read_struct_point(mut buffer: &mut String) -> Result<Point, Box<dyn std::error::Error>> {
+    let name = read_line(&mut buffer).parse()?;
+    let description = read_line(&mut buffer).to_string();
+    let pos = read_line(&mut buffer).parse()?;
+    Ok(Point { name, description, pos })
 }
 
-fn read_struct_chars() -> Chars {
-    let line = read_line();
-    let words: Vec<&str> = line.split_whitespace().collect();
-    Chars {
-        first_char: words[0].parse().unwrap(),
-        second_char: words[1].parse().unwrap(),
-        third_char: words[2].parse().unwrap(),
+impl std::str::FromStr for Chars {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        let mut line = line.split_whitespace();
+        Ok(Self {
+            first_char: line.next().ok_or("missing `first_char`")?.parse()?,
+            second_char: line.next().ok_or("missing `second_char`")?.parse()?,
+            third_char: line.next().ok_or("missing `third_char`")?.parse()?,
+        })
     }
 }


### PR DESCRIPTION
I changed many things on how the generated Rust parsers behave, maybe we don't want all of these changes.


### Derive traits

I added some auto trait implementations with `#[derive(Clone, Debug, Eq, Hash, PartialEq)]`, it isn't really important but it makes us look fancy and sometime people might forget that they are not here.


### Use a single buffer

Maybe I overengineered here but I think that one of the nice designs of Rust is that it makes you think hard about when you are making memory allocation (typically when using `::new()`, `::clone()`).

There is now one memory allocation for input buffer (plus a few realloc) and exactly one for each list in the input, isn't that cool ? Note that it will probably not change performances in our use case. :(


### In-lining list parsing

I think this isn't too heavy for the main function, it also makes it easier to change the integer type for the candidate. This last point is quite important because `i32` is often not very convenient to work with, for example when it has to be compared with `usize`.


### Use FromStr for one-line structs

It makes us stylish to use `string.parse()` to read a struct. I also think it is really way better to work with traits from standard library when there is one corresponding to our use case.


### Remove all `unwrap()`

I think that `unwrap()` should never be used in a clean codebase, except in places where we are sure that no error can be raised. Plus I don't like how competitive programming people always write extremely short and extremely ugly code, so I like the idea of pushing in the total opposite direction :D


### Use of `collect()` to build vectors

It is just more idiomatic, I think it generates exactly the same binary here.


**NOTE**: I wasn't able to run tests, I might need some help with that :(
**NOTE**: I really didn't enjoy this Python formater :'(