### PR TITLE
Math notations using mathjax

### DIFF
--- a/iorgen/markdown.py
+++ b/iorgen/markdown.py
@@ -182,10 +182,10 @@ def constraints(variables: List[Variable], lang: Dict[str, str]) -> str:
     output = []
     if l_simple:
         output.extend(["", "### {}".format(lang['constraints']), ""])
-        output.extend(["- " + i for i in l_simple])
+        output.extend([f"- ${i}$" for i in l_simple])
     if l_perf:
         output.extend(["", "### {}".format(lang['constraints perf']), ""])
-        output.extend(["- " + i for i in l_perf])
+        output.extend([f"- ${i}$" for i in l_perf])
     return "\n".join(output + [""])
 
 

--- a/iorgen/types.py
+++ b/iorgen/types.py
@@ -6,7 +6,10 @@
 import re
 from enum import Enum, unique
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
-from typing import Type as T, TypeVar, Union
+from typing import Type as T
+from typing import TypeVar, Union
+
+from .utils import str_int
 
 # This stuff is no longer necessary with python 3.7 by including:
 # from __future__ import annotations
@@ -142,7 +145,7 @@ def integer_bounds(name: str, min_: Union[int, VAR], max_: Union[int, VAR],
     min_repr = ""
     if isinstance(min_, int):
         if min_ != Constraints.MIN_INT:
-            min_repr = str(max(0, min_) if is_size else min_)
+            min_repr = str_int(max(0, min_) if is_size else min_)
         elif is_size:
             min_repr = "0"
     elif isinstance(min_, Variable):
@@ -153,7 +156,7 @@ def integer_bounds(name: str, min_: Union[int, VAR], max_: Union[int, VAR],
             min_repr = "0, " + min_repr
     max_repr = ""
     if isinstance(max_, int) and max_ != Constraints.MAX_INT:
-        max_repr = str(max_)
+        max_repr = str_int(max_)
     elif isinstance(max_, Variable):
         max_repr = max_.name
 
@@ -161,9 +164,9 @@ def integer_bounds(name: str, min_: Union[int, VAR], max_: Union[int, VAR],
         return ""
     out = name
     if min_repr:
-        out = min_repr + " ≤ " + out
+        out = min_repr + r" \le " + out
     if max_repr:
-        out = out + " ≤ " + max_repr
+        out = out + r" \le " + max_repr
     return out
 
 
@@ -218,9 +221,9 @@ class Constraints:
         return value
 
     def simple_repr(self, name: str) -> str:
-        """Return text representation of integer bounds"""
+        """Return mathjax representation of integer bounds"""
         if self.choices:
-            return "{} ϵ {{{}}}".format(
+            return r"{} \in \{{{}\}}".format(
                 name, (", ".join(str(i) for i in sorted(self.choices))))
         return integer_bounds(name, self.min, self.max, self.is_size)
 
@@ -275,7 +278,7 @@ class Variable:
                 name) if perf else self.constraints.simple_repr(name)
         if type_ == TypeEnum.CHAR:
             if self.constraints.choices and not perf:
-                return "{} ϵ {{{}}}".format(name, (", ".join(
+                return r"{} \in \{{{}\}}".format(name, (", ".join(
                     str(i) for i in sorted(self.constraints.choices))))
             return ""
         raise Exception

--- a/iorgen/utils.py
+++ b/iorgen/utils.py
@@ -30,6 +30,11 @@ def int_to_iterator_name(value: int, times: int = 1) -> str:
     return int_to_iterator_name(value - 18, times + 1)
 
 
+def str_int(value: int) -> str:
+    """Return integer mathjax representation"""
+    return f"{value:,}".replace(',', r'\,')
+
+
 class IteratorName:
     """Give valid iterator names, like i, j, k, preventing scope conflicts"""
     def __init__(self, existing_names: List[str]) -> None:

--- a/test/samples/emptylines/emptylines.en.md
+++ b/test/samples/emptylines/emptylines.en.md
@@ -39,5 +39,5 @@ Wow, lots of empty lines!
 
 ### Constraints
 
-- 0 ≤ N
-- 0 ≤ size
+- $0 \le N$
+- $0 \le size$

--- a/test/samples/emptylines/emptylines.fr.md
+++ b/test/samples/emptylines/emptylines.fr.md
@@ -42,5 +42,5 @@ Wow, lots of empty lines!
 
 ### Contraintes
 
-- 0 ≤ N
-- 0 ≤ size
+- $0 \le N$
+- $0 \le size$

--- a/test/samples/example/example.en.md
+++ b/test/samples/example/example.en.md
@@ -18,10 +18,10 @@ do with this generated code
 
 ### Constraints
 
-- 1 ≤ N ≤ 10
-- integer ϵ {-4, 42, 1337}
-- character ϵ {a, b, c}
+- $1 \le N \le 10$
+- $integer \in \{-4, 42, 1337\}$
+- $character \in \{a, b, c\}$
 
 ### Performance constraints
 
-- 1 ≤ N ≤ 10000
+- $1 \le N \le 10\,000$

--- a/test/samples/example/example.fr.md
+++ b/test/samples/example/example.fr.md
@@ -19,10 +19,10 @@ do with this generated code
 
 ### Contraintes
 
-- 1 ≤ N ≤ 10
-- integer ϵ {-4, 42, 1337}
-- character ϵ {a, b, c}
+- $1 \le N \le 10$
+- $integer \in \{-4, 42, 1337\}$
+- $character \in \{a, b, c\}$
 
 ### Contraintes de performance
 
-- 1 ≤ N ≤ 10000
+- $1 \le N \le 10\,000$

--- a/test/samples/keywords/keywords.en.md
+++ b/test/samples/keywords/keywords.en.md
@@ -29,5 +29,5 @@ If this compiles, it is already a good step!
 
 ### Constraints
 
-- 0 ≤ if
-- for[ ] ϵ {1, 2, 345, 689}
+- $0 \le if$
+- $for[ ] \in \{1, 2, 345, 689\}$

--- a/test/samples/keywords/keywords.fr.md
+++ b/test/samples/keywords/keywords.fr.md
@@ -32,5 +32,5 @@ If this compiles, it is already a good step!
 
 ### Contraintes
 
-- 0 ≤ if
-- for[ ] ϵ {1, 2, 345, 689}
+- $0 \le if$
+- $for[ ] \in \{1, 2, 345, 689\}$

--- a/test/samples/lists/lists.en.md
+++ b/test/samples/lists/lists.en.md
@@ -26,12 +26,12 @@ Aren't these lists beautifull?
 
 ### Constraints
 
-- 1 ≤ N ≤ 10
-- 1 ≤ (list int)[ ] ≤ 2000
-- 0 ≤ size ≤ 5
-- (list char)[ ] ϵ {f, o}
-- 0 ≤ matrix[ ] ≤ 3456
+- $1 \le N \le 10$
+- $1 \le (list int)[ ] \le 2\,000$
+- $0 \le size \le 5$
+- $(list char)[ ] \in \{f, o\}$
+- $0 \le matrix[ ] \le 3\,456$
 
 ### Performance constraints
 
-- 0 ≤ matrix[ ] ≤ 10000
+- $0 \le matrix[ ] \le 10\,000$

--- a/test/samples/lists/lists.fr.md
+++ b/test/samples/lists/lists.fr.md
@@ -28,12 +28,12 @@ Aren't these lists beautifull?
 
 ### Contraintes
 
-- 1 ≤ N ≤ 10
-- 1 ≤ (list int)[ ] ≤ 2000
-- 0 ≤ size ≤ 5
-- (list char)[ ] ϵ {f, o}
-- 0 ≤ matrix[ ] ≤ 3456
+- $1 \le N \le 10$
+- $1 \le (list int)[ ] \le 2\,000$
+- $0 \le size \le 5$
+- $(list char)[ ] \in \{f, o\}$
+- $0 \le matrix[ ] \le 3\,456$
 
 ### Contraintes de performance
 
-- 0 ≤ matrix[ ] ≤ 10000
+- $0 \le matrix[ ] \le 10\,000$

--- a/test/samples/simple/simple.en.md
+++ b/test/samples/simple/simple.en.md
@@ -15,9 +15,9 @@ Just do what you want with these numbers, like sum them.
 
 ### Constraints
 
-- -3 ≤ N ≤ 123456789
-- other number ≤ N
+- $-3 \le N \le 123\,456\,789$
+- $other number \le N$
 
 ### Performance constraints
 
-- -3 ≤ N ≤ 1234567890
+- $-3 \le N \le 1\,234\,567\,890$

--- a/test/samples/simple/simple.fr.md
+++ b/test/samples/simple/simple.fr.md
@@ -15,9 +15,9 @@ Just do what you want with these numbers, like sum them.
 
 ### Contraintes
 
-- -3 ≤ N ≤ 123456789
-- other number ≤ N
+- $-3 \le N \le 123\,456\,789$
+- $other number \le N$
 
 ### Contraintes de performance
 
-- -3 ≤ N ≤ 1234567890
+- $-3 \le N \le 1\,234\,567\,890$

--- a/test/samples/sizedstruct/sizedstruct.en.md
+++ b/test/samples/sizedstruct/sizedstruct.en.md
@@ -40,7 +40,7 @@ The is a special case.
 
 ### Constraints
 
-- 0 ≤ n
-- 0 ≤ size1
-- 1 ≤ size2
-- 0 ≤ size3
+- $0 \le n$
+- $0 \le size1$
+- $1 \le size2$
+- $0 \le size3$

--- a/test/samples/sizedstruct/sizedstruct.fr.md
+++ b/test/samples/sizedstruct/sizedstruct.fr.md
@@ -44,7 +44,7 @@ The is a special case.
 
 ### Contraintes
 
-- 0 ≤ n
-- 0 ≤ size1
-- 1 ≤ size2
-- 0 ≤ size3
+- $0 \le n$
+- $0 \le size1$
+- $1 \le size2$
+- $0 \le size3$

--- a/test/samples/structs/structs.en.md
+++ b/test/samples/structs/structs.en.md
@@ -32,11 +32,11 @@ Look at them structs.
 
 ### Constraints
 
-- 0 ≤ n
-- foo ϵ {1, 3, 8, 28, 43}
-- 2 ≤ bar ≤ 99
-- name ϵ {A, B, O}
+- $0 \le n$
+- $foo \in \{1, 3, 8, 28, 43\}$
+- $2 \le bar \le 99$
+- $name \in \{A, B, O\}$
 
 ### Performance constraints
 
-- 2 ≤ n
+- $2 \le n$

--- a/test/samples/structs/structs.fr.md
+++ b/test/samples/structs/structs.fr.md
@@ -34,11 +34,11 @@ Look at them structs.
 
 ### Contraintes
 
-- 0 ≤ n
-- foo ϵ {1, 3, 8, 28, 43}
-- 2 ≤ bar ≤ 99
-- name ϵ {A, B, O}
+- $0 \le n$
+- $foo \in \{1, 3, 8, 28, 43\}$
+- $2 \le bar \le 99$
+- $name \in \{A, B, O\}$
 
 ### Contraintes de performance
 
-- 2 ≤ n
+- $2 \le n$


### PR DESCRIPTION
Improve readability of mathematical expressions in constraints using mathjax notation and adding fine space characters as thousand separators in numbers.

It could also be great to change variables names from `**var**` to `$var$` but only if the var is an integer.