### PR TITLE
Fix Rust generator expecting errors where there are none

### DIFF
--- a/iorgen/__main__.py
+++ b/iorgen/__main__.py
@@ -134,7 +134,8 @@ def main() -> None:
         path.write_text(languages[language].generate(input_data))
     path = Path(os.path.join(args.output_dir, "..", "subject-io-stub.md"))
     if args.markdown != "None":
-        path.write_text(gen_markdown(input_data, args.markdown))
+        path.write_text(gen_markdown(input_data, args.markdown),
+                        encoding='utf-8')
 
 
 if __name__ == '__main__':

--- a/iorgen/parser_rust.py
+++ b/iorgen/parser_rust.py
@@ -68,7 +68,8 @@ def parse_without_error(type_: Type) -> bool:
 
     if type_.main == TypeEnum.LIST:
         assert type_.encapsulated is not None
-        return type_.encapsulated.main == TypeEnum.CHAR
+        return type_.encapsulated.main == TypeEnum.CHAR or parse_without_error(
+            type_.encapsulated)
 
     return False
 

--- a/iorgen/parser_rust.py
+++ b/iorgen/parser_rust.py
@@ -362,7 +362,7 @@ class ParserRust():
             assert type_.encapsulated is not None
             inner_name = name.replace(".", "_") + "_elem"
             return [
-                f"{idt}for {inner_name} in &{name} {{",
+                f"{idt}for {inner_name} in {name}.iter() {{",
                 *self.print_lines(inner_name, type_.encapsulated,
                                   indent_lvl + 1),
                 f"{idt}}}",

--- a/test/samples/lists/lists.c
+++ b/test/samples/lists/lists.c
@@ -7,8 +7,9 @@
 /// \param list_char a list of char
 /// \param string a string
 /// \param list_string4 a list of strings of size 4
+/// \param list_list_string2 a list of list of strings of size 2 of size 2 of size 2
 /// \param matrix a matrix of int
-void lists(int n, int* list_int, int size, char* list_char, char* string, char** list_string4, int** matrix) {
+void lists(int n, int* list_int, int size, char* list_char, char* string, char** list_string4, char*** list_list_string2, int** matrix) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -33,13 +34,22 @@ int main() {
         scanf("%[^\n]", list_string4[i]);
         getchar(); // \n
     }
+    char*** list_list_string2 = (char***)malloc(2 * sizeof(char**));
+    for (int i = 0; i < 2; ++i) {
+        list_list_string2[i] = (char**)malloc(2 * sizeof(char*));
+        for (int j = 0; j < 2; ++j) {
+            list_list_string2[i][j] = (char*)malloc((2 + 1) * sizeof(char));
+            scanf("%[^\n]", list_list_string2[i][j]);
+            getchar(); // \n
+        }
+    }
     int** matrix = (int**)malloc(size * sizeof(int*));
     for (int i = 0; i < size; ++i) {
         matrix[i] = (int*)malloc(size * sizeof(int));
         for (int j = 0; j < size; ++j)
             scanf("%d", &matrix[i][j]);
     }
-    lists(n, list_int, size, list_char, string, list_string4, matrix);
+    lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix);
 
     return 0;
 }

--- a/test/samples/lists/lists.cpp
+++ b/test/samples/lists/lists.cpp
@@ -9,8 +9,9 @@
 /// \param list_char a list of char
 /// \param string a string
 /// \param list_string4 a list of strings of size 4
+/// \param list_list_string2 a list of list of strings of size 2 of size 2 of size 2
 /// \param matrix a matrix of int
-void lists(int n, const std::vector<int>& list_int, int size, const std::vector<char>& list_char, const std::string& string, const std::vector<std::string>& list_string4, const std::vector<std::vector<int>>& matrix) {
+void lists(int n, const std::vector<int>& list_int, int size, const std::vector<char>& list_char, const std::string& string, const std::vector<std::string>& list_string4, const std::vector<std::vector<std::string>>& list_list_string2, const std::vector<std::vector<int>>& matrix) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -31,11 +32,18 @@ int main() {
     for (std::string& i : list_string4) {
         std::getline(std::cin >> std::ws, i);
     }
+    std::vector<std::vector<std::string>> list_list_string2(2); ///< a list of list of strings of size 2 of size 2 of size 2
+    for (std::vector<std::string>& i : list_list_string2) {
+        i.resize(2);
+        for (std::string& j : i) {
+            std::getline(std::cin >> std::ws, j);
+        }
+    }
     std::vector<std::vector<int>> matrix(size); ///< a matrix of int
     for (std::vector<int>& i : matrix) {
         i.resize(size);
         for (int& j : i)
             std::cin >> j;
     }
-    lists(n, list_int, size, list_char, string, list_string4, matrix);
+    lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix);
 }

--- a/test/samples/lists/lists.cs
+++ b/test/samples/lists/lists.cs
@@ -8,8 +8,9 @@ class Program
     /// \param listChar a list of char
     /// \param @string a string
     /// \param listString4 a list of strings of size 4
+    /// \param listListString2 a list of list of strings of size 2 of size 2 of size 2
     /// \param matrix a matrix of int
-    static void Lists(int n, int[] listInt, int size, char[] listChar, string @string, string[] listString4, int[][] matrix)
+    static void Lists(int n, int[] listInt, int size, char[] listChar, string @string, string[] listString4, string[][] listListString2, int[][] matrix)
     {
         /* TODO Aren't these lists beautifull? */
     }
@@ -26,12 +27,21 @@ class Program
         {
             listString4[i] = Console.ReadLine();
         }
+        string[][] listListString2 = new string[2][];
+        for (int i = 0; i < 2; ++i)
+        {
+            listListString2[i] = new string[2];
+            for (int j = 0; j < 2; ++j)
+            {
+                listListString2[i][j] = Console.ReadLine();
+            }
+        }
         int[][] matrix = new int[size][];
         for (int i = 0; i < size; ++i)
         {
             matrix[i] = Array.ConvertAll(Console.ReadLine().Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries), int.Parse);
         }
 
-        Lists(n, listInt, size, listChar, @string, listString4, matrix);
+        Lists(n, listInt, size, listChar, @string, listString4, listListString2, matrix);
     }
 }

--- a/test/samples/lists/lists.d
+++ b/test/samples/lists/lists.d
@@ -12,9 +12,10 @@ Params:
     listChar = a list of char
     string_ = a string
     listString4 = a list of strings of size 4
+    listListString2 = a list of list of strings of size 2 of size 2 of size 2
     matrix = a matrix of int
 */
-void lists(int n, int[] listInt, int size, char[] listChar, string string_, string[] listString4, int[][] matrix)
+void lists(int n, int[] listInt, int size, char[] listChar, string string_, string[] listString4, string[][] listListString2, int[][] matrix)
 {
     // TODO Aren't these lists beautifull?
 }
@@ -37,6 +38,16 @@ void main()
     {
         stdin.readf("%s\n", &listString4[i]);
     }
+    string[][] listListString2;
+    listListString2.length = 2;
+    for (size_t i = 0; i < listListString2.length; i++)
+    {
+        listListString2[i].length = 2;
+        for (size_t j = 0; j < listListString2[i].length; j++)
+        {
+            stdin.readf("%s\n", &listListString2[i][j]);
+        }
+    }
     int[][] matrix;
     matrix.length = size;
     for (size_t i = 0; i < matrix.length; i++)
@@ -44,5 +55,5 @@ void main()
         matrix[i] = stdin.readln.split.map!(to!int).array;
     }
 
-    lists(n, listInt, size, listChar, string_, listString4, matrix);
+    lists(n, listInt, size, listChar, string_, listString4, listListString2, matrix);
 }

--- a/test/samples/lists/lists.en.md
+++ b/test/samples/lists/lists.en.md
@@ -16,6 +16,10 @@ The input will contain:
 - On the next lines, a list of **size** elements: **list string4**, a list of
   strings of size 4.
     - One line per list element: a string of size **4**.
+- On the next lines, a list of **2** elements: **list list string2**, a list of
+  list of strings of size 2 of size 2 of size 2.
+    - Each list element is on several lines: a list of **2** elements.
+        - One line per list element: a string of size **2**.
 - On the next lines, a list of **size** elements: **matrix**, a matrix of int.
     - One line per list element: a list of **size** integers separated by
       spaces.

--- a/test/samples/lists/lists.fr.md
+++ b/test/samples/lists/lists.fr.md
@@ -17,6 +17,11 @@ L’entrée contiendra :
 - Sur les lignes suivantes, une liste de **size** éléments : **list string4**,
   a list of strings of size 4.
     - Une ligne par élément de la liste : une chaine de **4** caractères.
+- Sur les lignes suivantes, une liste de **2** éléments : **list list
+  string2**, a list of list of strings of size 2 of size 2 of size 2.
+    - Chaque élément de la liste est sur plusieurs lignes : une liste de **2**
+      éléments.
+        - Une ligne par élément de la liste : une chaine de **2** caractères.
 - Sur les lignes suivantes, une liste de **size** éléments : **matrix**, a
   matrix of int.
     - Une ligne par élément de la liste : une liste de **size** entiers séparés

--- a/test/samples/lists/lists.go
+++ b/test/samples/lists/lists.go
@@ -11,8 +11,9 @@ import "strings"
 // listChar: a list of char
 // string_: a string
 // listString4: a list of strings of size 4
+// listListString2: a list of list of strings of size 2 of size 2 of size 2
 // matrix: a matrix of int
-func lists(n int, listInt []int, size int, listChar []byte, string_ string, listString4 []string, matrix [][]int) {
+func lists(n int, listInt []int, size int, listChar []byte, string_ string, listString4 []string, listListString2 [][]string, matrix [][]int) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -40,6 +41,14 @@ func main() {
         scanner.Scan()
         listString4[i] = scanner.Text()
     }
+    listListString2 := make([][]string, 2)
+    for i := range listListString2 {
+        listListString2[i] = make([]string, 2)
+        for j := range listListString2[i] {
+            scanner.Scan()
+            listListString2[i][j] = scanner.Text()
+        }
+    }
     matrix := make([][]int, size)
     for i := range matrix {
         matrix[i] = make([]int, size)
@@ -48,5 +57,5 @@ func main() {
             matrix[i][j], _ = strconv.Atoi(jValue)
         }
     }
-    lists(n, listInt, size, listChar, string_, listString4, matrix);
+    lists(n, listInt, size, listChar, string_, listString4, listListString2, matrix);
 }

--- a/test/samples/lists/lists.hs
+++ b/test/samples/lists/lists.hs
@@ -1,15 +1,16 @@
 import Control.Monad (replicateM)
 
-lists :: Int       -- ^ the first list's size
-      -> [Int]     -- ^ a list containing ints
-      -> Int       -- ^ an other size
-      -> [Char]    -- ^ a list of char
-      -> String    -- ^ a string
-      -> [String]  -- ^ a list of strings of size 4
-      -> [[Int]]   -- ^ a matrix of int
-      -> String    -- ^ TODO
+lists :: Int         -- ^ the first list's size
+      -> [Int]       -- ^ a list containing ints
+      -> Int         -- ^ an other size
+      -> [Char]      -- ^ a list of char
+      -> String      -- ^ a string
+      -> [String]    -- ^ a list of strings of size 4
+      -> [[String]]  -- ^ a list of list of strings of size 2 of size 2 of size 2
+      -> [[Int]]     -- ^ a matrix of int
+      -> String      -- ^ TODO
 -- Aren't these lists beautifull?
-lists n listInt size listChar string listString4 matrix = "TODO"
+lists n listInt size listChar string listString4 listListString2 matrix = "TODO"
 
 main :: IO ()
 main = do
@@ -19,5 +20,6 @@ main = do
   listChar <- getLine
   string <- getLine
   listString4 <- replicateM size getLine
+  listListString2 <- replicateM 2 $ replicateM 2 getLine
   matrix <- replicateM size $ fmap (map read . words) getLine
-  putStrLn $ lists n listInt size listChar string listString4 matrix
+  putStrLn $ lists n listInt size listChar string listString4 listListString2 matrix

--- a/test/samples/lists/lists.java
+++ b/test/samples/lists/lists.java
@@ -9,9 +9,10 @@ class Main {
      * @param listChar a list of char
      * @param string a string
      * @param listString4 a list of strings of size 4
+     * @param listListString2 a list of list of strings of size 2 of size 2 of size 2
      * @param matrix a matrix of int
      */
-    static void lists(int n, int[] listInt, int size, char[] listChar, String string, String[] listString4, int[][] matrix) {
+    static void lists(int n, int[] listInt, int size, char[] listChar, String string, String[] listString4, String[][] listListString2, int[][] matrix) {
         /* TODO Aren't these lists beautifull? */
     }
 
@@ -26,11 +27,18 @@ class Main {
         for (int i = 0; i < size; ++i) {
             listString4[i] = scanner.nextLine();
         }
+        String[][] listListString2 = new String[2][];
+        for (int i = 0; i < 2; ++i) {
+            listListString2[i] = new String[2];
+            for (int j = 0; j < 2; ++j) {
+                listListString2[i][j] = scanner.nextLine();
+            }
+        }
         int[][] matrix = new int[size][];
         for (int i = 0; i < size; ++i) {
             matrix[i] = Arrays.stream(scanner.nextLine().split(" ")).filter(x -> !x.isEmpty()).mapToInt(Integer::parseInt).toArray();
         }
 
-        lists(n, listInt, size, listChar, string, listString4, matrix);
+        lists(n, listInt, size, listChar, string, listString4, listListString2, matrix);
     }
 }

--- a/test/samples/lists/lists.js
+++ b/test/samples/lists/lists.js
@@ -7,10 +7,11 @@
  * @param {Array.<string>} listChar a list of char
  * @param {string} string a string
  * @param {Array.<string>} listString4 a list of strings of size 4
+ * @param {Array.<Array.<string>>} listListString2 a list of list of strings of size 2 of size 2 of size 2
  * @param {Array.<Array.<number>>} matrix a matrix of int
  * @returns {void}
  */
-function lists(n, listInt, size, listChar, string, listString4, matrix) {
+function lists(n, listInt, size, listChar, string, listString4, listListString2, matrix) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -27,12 +28,21 @@ function main(stdin) {
         const j = stdin[line++];
         listString4.push(j);
     }
+    const listListString2 = [];
+    for (let i = 0; i < 2; i++) {
+        const j = [];
+        for (let k = 0; k < 2; k++) {
+            const l = stdin[line++];
+            j.push(l);
+        }
+        listListString2.push(j);
+    }
     const matrix = [];
     for (let i = 0; i < size; i++) {
         const j = stdin[line++].split(" ", size).map(Number);
         matrix.push(j);
     }
-    lists(n, listInt, size, listChar, string, listString4, matrix);
+    lists(n, listInt, size, listChar, string, listString4, listListString2, matrix);
 }
 
 let stdin = "";

--- a/test/samples/lists/lists.lua
+++ b/test/samples/lists/lists.lua
@@ -4,8 +4,9 @@
 -- list_char (table: array[string]): a list of char
 -- string_ (string): a string
 -- list_string4 (table: array[string]): a list of strings of size 4
+-- list_list_string2 (table: array[array[string]]): a list of list of strings of size 2 of size 2 of size 2
 -- matrix (table: array[array[number]]): a matrix of int
-function lists(n, list_int, size, list_char, string_, list_string4, matrix)
+function lists(n, list_int, size, list_char, string_, list_string4, list_list_string2, matrix)
     -- TODO Aren't these lists beautifull?
 end
 
@@ -22,6 +23,13 @@ local list_string4 = {}
 for i = 1, size do
     list_string4[i] = io.read()
 end
+local list_list_string2 = {}
+for i = 1, 2 do
+    list_list_string2[i] = {}
+    for j = 1, 2 do
+        list_list_string2[i][j] = io.read()
+    end
+end
 local matrix = {}
 for i = 1, size do
     matrix[i] = {}
@@ -30,4 +38,4 @@ for i = 1, size do
     end
 end
 
-lists(n, list_int, size, list_char, string_, list_string4, matrix)
+lists(n, list_int, size, list_char, string_, list_string4, list_list_string2, matrix)

--- a/test/samples/lists/lists.ml
+++ b/test/samples/lists/lists.ml
@@ -33,9 +33,10 @@ end
    @param listChar a list of char
    @param string a string
    @param listString4 a list of strings of size 4
+   @param listListString2 a list of list of strings of size 2 of size 2 of size 2
    @param matrix a matrix of int
 *)
-let lists n listInt size listChar string listString4 matrix =
+let lists n listInt size listChar string listString4 listListString2 matrix =
   (** TODO Aren't these lists beautifull? *)
   ()
 
@@ -46,5 +47,6 @@ let () =
   let listChar = List.init size (String.get (read_line ())) in
   let string = read_line () in
   let listString4 = List.init size (fun _ -> read_line ()) in
+  let listListString2 = List.init 2 (fun _ -> List.init 2 (fun _ -> read_line ())) in
   let matrix = List.init size (fun _ -> read_line () |> fun x -> if x = "" then [] else String.split_on_char ' ' x |> List.rev_map int_of_string |> List.rev) in
-  lists n listInt size listChar string listString4 matrix
+  lists n listInt size listChar string listString4 listListString2 matrix

--- a/test/samples/lists/lists.pas
+++ b/test/samples/lists/lists.pas
@@ -3,6 +3,7 @@ program Lists;
 type
     T_ListInt = array of longint;
     T_ListString4 = array of string;
+    T_ListListString2 = array of array of string;
     T_Matrix = array of array of longint;
 
 { @param N the first list's size }
@@ -11,8 +12,9 @@ type
 { @param ListChar a list of char }
 { @param String_ a string }
 { @param ListString4 a list of strings of size 4 }
+{ @param ListListString2 a list of list of strings of size 2 of size 2 of size 2 }
 { @param Matrix a matrix of int }
-procedure Lists(N: longint; const ListInt: T_ListInt; Size: longint; const ListChar: string; const String_: string; const ListString4: T_ListString4; const Matrix: T_Matrix);
+procedure Lists(N: longint; const ListInt: T_ListInt; Size: longint; const ListChar: string; const String_: string; const ListString4: T_ListString4; const ListListString2: T_ListListString2; const Matrix: T_Matrix);
 begin
     {* TODO Aren't these lists beautifull? *}
 end;
@@ -24,6 +26,7 @@ var
     ListChar: string; { a list of char }
     String_: string; { a string }
     ListString4: T_ListString4; { a list of strings of size 4 }
+    ListListString2: T_ListListString2; { a list of list of strings of size 2 of size 2 of size 2 }
     Matrix: T_Matrix; { a matrix of int }
     i, j: longint;
 begin
@@ -40,6 +43,14 @@ begin
     begin
         readln(ListString4[i]);
     end;
+    setLength(ListListString2, 2, 2);
+    for i := 0 to 2 - 1 do
+    begin
+        for j := 0 to 2 - 1 do
+        begin
+            readln(ListListString2[i][j]);
+        end;
+    end;
     setLength(Matrix, Size, Size);
     for i := 0 to Size - 1 do
     begin
@@ -47,5 +58,5 @@ begin
             read(Matrix[i][j]);
         readln();
     end;
-    Lists(N, ListInt, Size, ListChar, String_, ListString4, Matrix);
+    Lists(N, ListInt, Size, ListChar, String_, ListString4, ListListString2, Matrix);
 end.

--- a/test/samples/lists/lists.php
+++ b/test/samples/lists/lists.php
@@ -6,9 +6,10 @@
  * @param string[] $list_char a list of char
  * @param string $string a string
  * @param string[] $list_string4 a list of strings of size 4
+ * @param string[][] $list_list_string2 a list of list of strings of size 2 of size 2 of size 2
  * @param int[][] $matrix a matrix of int
  */
-function lists($n, &$list_int, $size, &$list_char, &$string, &$list_string4, &$matrix) {
+function lists($n, &$list_int, $size, &$list_char, &$string, &$list_string4, &$list_list_string2, &$matrix) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -21,8 +22,15 @@ $list_string4 = [];
 for ($i = 0; $i < $size; $i++) {
     $list_string4[$i] = trim(fgets(STDIN));
 }
+$list_list_string2 = [];
+for ($i = 0; $i < 2; $i++) {
+    $list_list_string2[$i] = [];
+    for ($j = 0; $j < 2; $j++) {
+        $list_list_string2[$i][$j] = trim(fgets(STDIN));
+    }
+}
 $matrix = [];
 for ($i = 0; $i < $size; $i++) {
     $matrix[$i] = array_map('intval', preg_split('/ /', trim(fgets(STDIN)), -1, PREG_SPLIT_NO_EMPTY));
 }
-lists($n, $list_int, $size, $list_char, $string, $list_string4, $matrix);
+lists($n, $list_int, $size, $list_char, $string, $list_string4, $list_list_string2, $matrix);

--- a/test/samples/lists/lists.pl
+++ b/test/samples/lists/lists.pl
@@ -8,9 +8,10 @@ use warnings;
 # @list_char: a list of char
 # $string: a string
 # @list_string4: a list of strings of size 4
+# @list_list_string2: a list of list of strings of size 2 of size 2 of size 2
 # @matrix: a matrix of int
 sub lists {
-    my ($n, $list_int, $size, $list_char, $string, $list_string4, $matrix) = @_;
+    my ($n, $list_int, $size, $list_char, $string, $list_string4, $list_list_string2, $matrix) = @_;
     # TODO Aren't these lists beautifull?
 }
 
@@ -25,9 +26,17 @@ for (1..$size) {
     push(@list_string4, scalar(<>));
     chomp $list_string4[-1];
 }
+my @list_list_string2 = ();
+for (1..2) {
+    push(@list_list_string2, []);
+    for (1..2) {
+        push(@{$list_list_string2[-1]}, scalar(<>));
+        chomp $list_list_string2[-1][-1];
+    }
+}
 my @matrix = ();
 for (1..$size) {
     push(@matrix, \@{[map { int } split(/[ \n]/, <>)]});
 }
 
-lists($n, \@list_int, $size, \@list_char, $string, \@list_string4, \@matrix);
+lists($n, \@list_int, $size, \@list_char, $string, \@list_string4, \@list_list_string2, \@matrix);

--- a/test/samples/lists/lists.pro
+++ b/test/samples/lists/lists.pro
@@ -4,8 +4,9 @@
 % ListChar: a list of char
 % String: a string
 % ListString4: a list of strings of size 4
+% ListListString2: a list of list of strings of size 2 of size 2 of size 2
 % Matrix: a matrix of int
-lists(N, ListInt, Size, ListChar, String, ListString4, Matrix) :-
+lists(N, ListInt, Size, ListChar, String, ListString4, ListListString2, Matrix) :-
     % TODO Aren't these lists beautifull?
     nl.
 
@@ -25,5 +26,6 @@ read_list(Goal, N, [H|T]) :- call(Goal, H), M is N - 1, read_list(Goal, M, T).
     read_char_list(ListChar),
     read_line(String),
     read_list(read_line, Size, ListString4),
+    read_list(read_list(read_line, 2), 2, ListListString2),
     read_list(read_int_list, Size, Matrix),
-    lists(N, ListInt, Size, ListChar, String, ListString4, Matrix).
+    lists(N, ListInt, Size, ListChar, String, ListString4, ListListString2, Matrix).

--- a/test/samples/lists/lists.py
+++ b/test/samples/lists/lists.py
@@ -1,4 +1,4 @@
-def lists(n, list_int, size, list_char, string, list_string4, matrix):
+def lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix):
     """
     :param n: the first list's size
     :type n: int
@@ -12,6 +12,8 @@ def lists(n, list_int, size, list_char, string, list_string4, matrix):
     :type string: str
     :param list_string4: a list of strings of size 4
     :type list_string4: list[str]
+    :param list_list_string2: a list of list of strings of size 2 of size 2 of size 2
+    :type list_list_string2: list[list[str]]
     :param matrix: a matrix of int
     :type matrix: list[list[int]]
     """
@@ -26,5 +28,6 @@ if __name__ == '__main__':
     list_char = list(input())
     string = input()
     list_string4 = [input() for _ in range(size)]
+    list_list_string2 = [[input() for _ in range(2)] for _ in range(2)]
     matrix = [list(map(int, input().split())) for _ in range(size)]
-    lists(n, list_int, size, list_char, string, list_string4, matrix)
+    lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix)

--- a/test/samples/lists/lists.rb
+++ b/test/samples/lists/lists.rb
@@ -4,8 +4,9 @@
 # +list_char+:: a list of char
 # +string+:: a string
 # +list_string4+:: a list of strings of size 4
+# +list_list_string2+:: a list of list of strings of size 2 of size 2 of size 2
 # +matrix+:: a matrix of int
-def lists(n, list_int, size, list_char, string, list_string4, matrix)
+def lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix)
     # TODO Aren't these lists beautifull?
 end
 
@@ -15,6 +16,7 @@ size = STDIN.gets.to_i
 list_char = STDIN.gets.chomp.split("")
 string = STDIN.gets.chomp
 list_string4 = Array.new(size) { STDIN.gets.chomp }
+list_list_string2 = Array.new(2) { Array.new(2) { STDIN.gets.chomp } }
 matrix = Array.new(size) { STDIN.gets.split.map(&:to_i) }
 
-lists(n, list_int, size, list_char, string, list_string4, matrix)
+lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix)

--- a/test/samples/lists/lists.rs
+++ b/test/samples/lists/lists.rs
@@ -4,8 +4,9 @@
 /// * `list_char` - a list of char
 /// * `string` - a string
 /// * `list_string4` - a list of strings of size 4
+/// * `list_list_string2` - a list of list of strings of size 2 of size 2 of size 2
 /// * `matrix` - a matrix of int
-fn lists(n: i32, list_int: Vec<i32>, size: i32, list_char: Vec<char>, string: String, list_string4: Vec<String>, matrix: Vec<Vec<i32>>) {
+fn lists(n: i32, list_int: Vec<i32>, size: i32, list_char: Vec<char>, string: String, list_string4: Vec<String>, list_list_string2: Vec<Vec<String>>, matrix: Vec<Vec<i32>>) {
     /* TODO Aren't these lists beautifull? */
 }
 
@@ -34,6 +35,14 @@ fn main() {
         .map(|_| read_line(&mut buffer).to_string())
         .collect();
 
+    let list_list_string2 = (0..2)
+        .map(|_| {
+            (0..2)
+                .map(|_| read_line(&mut buffer).to_string())
+                .collect()
+        })
+        .collect();
+
     let matrix = (0..size)
         .map(|_| {
             read_line(&mut buffer)
@@ -44,7 +53,7 @@ fn main() {
         .collect::<Result<_, _>>()
         .expect("invalid `matrix` parameter");
 
-    lists(n, list_int, size, list_char, string, list_string4, matrix);
+    lists(n, list_int, size, list_char, string, list_string4, list_list_string2, matrix);
 }
 
 fn read_line(mut buffer: &mut String) -> &str {

--- a/test/samples/lists/lists.sample_input
+++ b/test/samples/lists/lists.sample_input
@@ -6,6 +6,10 @@ hello hello
 this
 that
 yes
+ab
+cd
+ef
+gh
 1 2 3
 1111 2222 3333
 9 8 7

--- a/test/samples/lists/lists.scm
+++ b/test/samples/lists/lists.scm
@@ -4,8 +4,9 @@
 ;;; list-char: a list of char
 ;;; string: a string
 ;;; list-string4: a list of strings of size 4
+;;; list-list-string2: a list of list of strings of size 2 of size 2 of size 2
 ;;; matrix: a matrix of int
-(define (lists n list-int size list-char string list-string4 matrix)
+(define (lists n list-int size list-char string list-string4 list-list-string2 matrix)
   ;;; TODO Aren't these lists beautifull?
   (newline))
 
@@ -26,5 +27,6 @@
        (list-char (string->list (read-line)))
        (string (read-line))
        (list-string4 (make-list size read-line))
+       (list-list-string2 (make-list 2 (lambda () (make-list 2 read-line))))
        (matrix (make-list size (lambda () (parse-int-list (read-line))))))
-  (lists n list-int size list-char string list-string4 matrix))
+  (lists n list-int size list-char string list-string4 list-list-string2 matrix))

--- a/test/samples/lists/lists.yaml
+++ b/test/samples/lists/lists.yaml
@@ -25,6 +25,9 @@ input:
     - type: List[str(4)](size)
       name: list string4
       comment: a list of strings of size 4
+    - type: List[List[str(2)](2)](2)
+      name: list list string2
+      comment: a list of list of strings of size 2 of size 2 of size 2
     - type: List[List[int](size)](size)
       name: matrix
       comment: a matrix of int


### PR DESCRIPTION
Due to some recent-ish changes, the expression parsing a list of changes now returns `Vec<String>` instead of `Result<Vec<String>, _>`.

This leads to issues where `collect::<Result<_, _>>()` is called instead of `collect()`, and a compile-time error. This fix simply adds `Vec<String>` to the list
of types that can be parsed without being wrapped in a result. `parse_without_error` probably should be recursive but heh.