### PR TITLE
ci: run CI with `--no_missing`

### DIFF
--- a/.github/workflows/iorgen-ci-compile-generated-code.yaml
+++ b/.github/workflows/iorgen-ci-compile-generated-code.yaml
@@ -25,5 +25,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U pyyaml
       - name: Run test suite
-        run: ./test.py
+        run: ./test.py --no_missing
         working-directory: ./test

--- a/iorgen/__main__.py
+++ b/iorgen/__main__.py
@@ -136,7 +136,7 @@ def main() -> None:
         for language in selected_languages:
             print(language, end=" ", flush=True)
             if not gen_compile_run_and_compare(
-                input_data, prefix, languages[language], "run", check_files, False
+                input_data, prefix, languages[language], "run", check_files
             ):
                 print("\nError with", language)
                 success = False

--- a/iorgen/generator.py
+++ b/iorgen/generator.py
@@ -157,7 +157,6 @@ def gen_compile_run_and_compare(
     language: Language,
     folder_for_generated_source: str,
     stdin_filename: List[str],
-    no_compile: bool = False,
 ) -> bool:
     # pylint: disable = too-many-arguments
     """Check that the generated parser prints the input it is fed in"""
@@ -174,9 +173,6 @@ def gen_compile_run_and_compare(
     generated = language.generator(input_data, True)
     Path(os.path.dirname(source)).mkdir(parents=True, exist_ok=True)
     Path(source).write_text(generated, encoding="utf-8")
-
-    if no_compile:
-        return True
 
     # Compile and compare
     exe = language.compile(source)

--- a/test/test.py
+++ b/test/test.py
@@ -52,15 +52,16 @@ def test_samples() -> None:
     args = parser.parse_args()
     selected_languages = args.languages or list(languages.keys())
     skipped_languages = []
-    for language in ALL_LANGUAGES:
-        if language.extension in selected_languages:
-            for command in (language.compile_command, language.exec_command):
-                if command and shutil.which(command[0]) is None:
-                    print(
-                        "WARNING: skip language "
-                        f"{language.extension} because `{command[0]}` is not found!"
-                    )
-                    skipped_languages.append(language.extension)
+    if not args.no_compilation:
+        for language in ALL_LANGUAGES:
+            if language.extension in selected_languages:
+                for command in (language.compile_command, language.exec_command):
+                    if command and shutil.which(command[0]) is None:
+                        print(
+                            "WARNING: skipping language "
+                            f"{language.extension} because `{command[0]}` is not found!"
+                        )
+                        skipped_languages.append(language.extension)
     assert not skipped_languages or not args.no_missing
 
     for name in os.listdir("samples"):
@@ -73,7 +74,8 @@ def test_samples() -> None:
         for language in ALL_LANGUAGES:
             assert gen_is_same_as_sample(input_data, prefix, language)
             if (
-                language.extension in selected_languages
+                not args.no_compilation
+                and language.extension in selected_languages
                 and language.extension not in skipped_languages
             ):
                 assert gen_compile_run_and_compare(
@@ -82,7 +84,6 @@ def test_samples() -> None:
                     language,
                     "tests",
                     [prefix + "sample_input"],
-                    args.no_compilation,
                 )
 
         for language in ALL_MARKDOWN:


### PR DESCRIPTION
- run compilation tests with `--no_missing`
- do not report a warning for uninstalled languages when using `--no_compilation`